### PR TITLE
Two unit test failure messages reference the wrong file.

### DIFF
--- a/BugTrackerUI.Tests/AddDataValidationToForm/AddFormatAttributesTests.cs
+++ b/BugTrackerUI.Tests/AddDataValidationToForm/AddFormatAttributesTests.cs
@@ -19,7 +19,7 @@ namespace M5_BugTrackerUI.Tests.AddDataValidationToForm
             var filePath = TestHelpers.GetRootString() + "BugTrackerUI"
                     + Path.DirectorySeparatorChar + "Bug.cs";
 
-            Assert.True(File.Exists(filePath), "`Bug.razor` should exist in the project root.");
+            Assert.True(File.Exists(filePath), "`Bug.cs` should exist in the project root.");
 
             var bug = TestHelpers.GetClassType("BugTrackerUI.Bug");
 

--- a/BugTrackerUI.Tests/AddDataValidationToForm/AddRequiredAttributesTests.cs
+++ b/BugTrackerUI.Tests/AddDataValidationToForm/AddRequiredAttributesTests.cs
@@ -19,7 +19,7 @@ namespace M5_BugTrackerUI.Tests.AddDataValidationToForm
             var filePath = TestHelpers.GetRootString() + "BugTrackerUI"
                     + Path.DirectorySeparatorChar + "Bug.cs";
 
-            Assert.True(File.Exists(filePath), "`Bug.razor` should exist in the project root.");
+            Assert.True(File.Exists(filePath), "`Bug.cs` should exist in the project root.");
 
             var bug = TestHelpers.GetClassType("BugTrackerUI.Bug");
 


### PR DESCRIPTION
When checking to ensure the Bug.cs file exists in the root of the project, the error message referenced "Bug.razor" instead of "Bug.cs".